### PR TITLE
transform.js: Skip rolegroup if there is only one active role

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -265,6 +265,11 @@ exports.getLdapGroupsWithoutMembers = (ctgroups, transformGroups, roles, dc) => 
     groups.push(grp);
 
     if (roles && roles.export && element.roles) {
+      const roleCount = element.roles.filter((r) => r.isActive).length;
+      if (roleCount <= 1) {
+        // do not export role if there is only one active role
+        return;
+      }
       element.roles.forEach((role) => {
         if (!role.isActive) return;
         let skip = false;


### PR DESCRIPTION
If there is only one active role, the rolegroup doesn't provide any additional value and might cause confusion for the user. Don't export it.