### PR TITLE
Check if cookie expired when doing CT API login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "axios": "^0.21.4",
+        "cookie": "^0.6.0",
         "ldap-escape": "^2.0.5",
         "ldap-filter": "^0.3.3",
         "ldapjs": "^2.3.1",
@@ -556,6 +557,14 @@
       "version": "1.0.11",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -3358,6 +3367,11 @@
     "confusing-browser-globals": {
       "version": "1.0.11",
       "dev": true
+    },
+    "cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="
     },
     "core-util-is": {
       "version": "1.0.2"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "axios": "^0.21.4",
+    "cookie": "^0.6.0",
     "ldap-escape": "^2.0.5",
     "ldap-filter": "^0.3.3",
     "ldapjs": "^2.3.1",


### PR DESCRIPTION
Otherwise we might use an expired cookie which causes unauthenticated API requests and therefore incomplete data to be returned.